### PR TITLE
ATHOS-1 Ajusta comando que recupera título do commit

### DIFF
--- a/template/hooks/commit-msg
+++ b/template/hooks/commit-msg
@@ -1,6 +1,6 @@
 #!/bin/sh
 MSG_FILE=$1
-MSG=$(head -n1 "$MSG_FILE")
+MSG=$(grep -E '^ATHOS-[0-9]+' "$MSG_FILE")
 
 # Verifica comprimento
 if [ ${#MSG} -gt 72 ]; then


### PR DESCRIPTION
Corrige comando para identificar linha exata do título do commit.
* Anterior
Assumia a primeira linha do commit message como título
* Correção
Linha de título é identificada pelo padrão principal de nomenclatura `<task-id>`